### PR TITLE
Refactor participatory budgets in draft mode

### DIFF
--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -14,6 +14,7 @@ class Admin::BudgetsController < Admin::BaseController
   end
 
   def show
+    render :edit
   end
 
   def new
@@ -22,6 +23,11 @@ class Admin::BudgetsController < Admin::BaseController
 
   def edit
     load_staff
+  end
+
+  def publish
+    @budget.publish!
+    redirect_to admin_budget_path(@budget), notice: t("admin.budgets.publish.notice")
   end
 
   def calculate_winners
@@ -70,6 +76,7 @@ class Admin::BudgetsController < Admin::BaseController
       descriptions = Budget::Phase::PHASE_KINDS.map { |p| "description_#{p}" }.map(&:to_sym)
       valid_attributes = [:phase,
                           :currency_symbol,
+                          :published,
                           administrator_ids: [],
                           valuator_ids: []
       ] + descriptions

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -27,7 +27,7 @@ class Admin::BudgetsController < Admin::BaseController
 
   def publish
     @budget.publish!
-    redirect_to admin_budget_path(@budget), notice: t("admin.budgets.publish.notice")
+    redirect_to edit_admin_budget_path(@budget), notice: t("admin.budgets.publish.notice")
   end
 
   def calculate_winners
@@ -52,7 +52,7 @@ class Admin::BudgetsController < Admin::BaseController
   def create
     @budget = Budget.new(budget_params.merge(published: false))
     if @budget.save
-      redirect_to admin_budget_path(@budget), notice: t("admin.budgets.create.notice")
+      redirect_to edit_admin_budget_path(@budget), notice: t("admin.budgets.create.notice")
     else
       load_staff
       render :new

--- a/app/controllers/admin/budgets_controller.rb
+++ b/app/controllers/admin/budgets_controller.rb
@@ -50,7 +50,7 @@ class Admin::BudgetsController < Admin::BaseController
   end
 
   def create
-    @budget = Budget.new(budget_params)
+    @budget = Budget.new(budget_params.merge(published: false))
     if @budget.save
       redirect_to admin_budget_path(@budget), notice: t("admin.budgets.create.notice")
     else
@@ -76,7 +76,6 @@ class Admin::BudgetsController < Admin::BaseController
       descriptions = Budget::Phase::PHASE_KINDS.map { |p| "description_#{p}" }.map(&:to_sym)
       valid_attributes = [:phase,
                           :currency_symbol,
-                          :published,
                           administrator_ids: [],
                           valuator_ids: []
       ] + descriptions

--- a/app/helpers/budgets_helper.rb
+++ b/app/helpers/budgets_helper.rb
@@ -62,7 +62,7 @@ module BudgetsHelper
   end
 
   def budget_published?(budget)
-    !budget.drafting? || current_user&.administrator?
+    budget.published? || current_user&.administrator?
   end
 
   def current_budget_map_locations

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -59,7 +59,7 @@ module Abilities
 
       can :manage, Dashboard::Action
 
-      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners], Budget
+      can [:index, :read, :new, :create, :update, :publish, :destroy, :calculate_winners], Budget
       can [:read, :create, :update, :destroy], Budget::Group
       can [:read, :create, :update, :destroy], Budget::Heading
       can [:hide, :admin_update, :toggle_selection], Budget::Investment

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -59,7 +59,8 @@ module Abilities
 
       can :manage, Dashboard::Action
 
-      can [:index, :read, :new, :create, :update, :publish, :destroy, :calculate_winners], Budget
+      can [:index, :read, :new, :create, :update, :destroy, :calculate_winners], Budget
+      can :publish, Budget, id: Budget.drafting.ids
       can [:read, :create, :update, :destroy], Budget::Group
       can [:read, :create, :update, :destroy], Budget::Heading
       can [:hide, :admin_update, :toggle_selection], Budget::Investment

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -41,7 +41,8 @@ class Budget < ApplicationRecord
 
   after_create :generate_phases
 
-  scope :drafting, -> { where(phase: "drafting") }
+  scope :drafting,  -> { where(published: false) }
+  scope :published, -> { where(published: true) }
   scope :informing, -> { where(phase: "informing") }
   scope :accepting, -> { where(phase: "accepting") }
   scope :reviewing, -> { where(phase: "reviewing") }
@@ -57,7 +58,7 @@ class Budget < ApplicationRecord
   scope :open, -> { where.not(phase: "finished") }
 
   def self.current
-    where.not(phase: "drafting").order(:created_at).last
+    published.order(:created_at).last
   end
 
   def current_phase
@@ -84,8 +85,12 @@ class Budget < ApplicationRecord
     80
   end
 
+  def publish!
+    update!(published: true)
+  end
+
   def drafting?
-    phase == "drafting"
+    published == false
   end
 
   def informing?

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -41,8 +41,8 @@ class Budget < ApplicationRecord
 
   after_create :generate_phases
 
-  scope :drafting,  -> { where(published: false) }
   scope :published, -> { where(published: true) }
+  scope :drafting,  -> { where.not(id: published) }
   scope :informing, -> { where(phase: "informing") }
   scope :accepting, -> { where(phase: "accepting") }
   scope :reviewing, -> { where(phase: "reviewing") }
@@ -90,7 +90,7 @@ class Budget < ApplicationRecord
   end
 
   def drafting?
-    published == false
+    !published?
   end
 
   def informing?

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -57,7 +57,7 @@ class Budget
     private
 
       def generate_slug?
-        slug.nil? || budget.drafting?
+        slug.nil? || budget&.drafting?
       end
   end
 end

--- a/app/models/budget/heading.rb
+++ b/app/models/budget/heading.rb
@@ -57,7 +57,7 @@ class Budget
     private
 
       def generate_slug?
-        slug.nil? || budget&.drafting?
+        slug.nil? || budget.drafting?
       end
   end
 end

--- a/app/models/budget/phase.rb
+++ b/app/models/budget/phase.rb
@@ -1,6 +1,6 @@
 class Budget
   class Phase < ApplicationRecord
-    PHASE_KINDS = %w[drafting informing accepting reviewing selecting valuating publishing_prices balloting
+    PHASE_KINDS = %w[informing accepting reviewing selecting valuating publishing_prices balloting
                 reviewing_ballots finished].freeze
     PUBLISHED_PRICES_PHASES = %w[publishing_prices balloting reviewing_ballots finished].freeze
     SUMMARY_MAX_LENGTH = 1000

--- a/app/views/admin/budgets/_drafting.html.erb
+++ b/app/views/admin/budgets/_drafting.html.erb
@@ -1,0 +1,16 @@
+<% if @budget.drafting? %>
+  <%= link_to t("admin.budgets.edit.publish"),
+              publish_admin_budget_path(@budget),
+              method: :patch, class: "button float-right",
+              data: { confirm: t("admin.actions.confirm") } %>
+<% end %>
+
+<%= link_to budget_path(@budget), class: "button hollow float-right", target: "_blank" do %>
+  <span class="far fa-eye"></span><%= t("admin.budgets.edit.preview") %>
+<% end %>
+
+<% if @budget.drafting? %>
+  <div class="callout warning">
+    <strong><%= t("admin.budgets.edit.drafting") %></strong>
+  </div>
+<% end %>

--- a/app/views/admin/budgets/_drafting.html.erb
+++ b/app/views/admin/budgets/_drafting.html.erb
@@ -1,4 +1,4 @@
-<% if @budget.drafting? %>
+<% if can? :publish, @budget %>
   <%= link_to t("admin.budgets.edit.publish"),
               publish_admin_budget_path(@budget),
               method: :patch, class: "button float-right",

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -21,6 +21,8 @@
     </div>
   </div>
 
+  <%= f.hidden_field :published, value: false unless @budget.persisted? %>
+
   <div class="row margin-top">
     <% %w[administrators valuators].each do |staff| %>
       <div class="small-12 medium-4 column end">

--- a/app/views/admin/budgets/_form.html.erb
+++ b/app/views/admin/budgets/_form.html.erb
@@ -21,8 +21,6 @@
     </div>
   </div>
 
-  <%= f.hidden_field :published, value: false unless @budget.persisted? %>
-
   <div class="row margin-top">
     <% %w[administrators valuators].each do |staff| %>
       <div class="small-12 medium-4 column end">

--- a/app/views/admin/budgets/edit.html.erb
+++ b/app/views/admin/budgets/edit.html.erb
@@ -6,4 +6,6 @@
   </div>
 </div>
 
+<%= render "/admin/budgets/drafting" %>
+
 <%= render "/admin/budgets/form" %>

--- a/app/views/admin/budgets/edit.html.erb
+++ b/app/views/admin/budgets/edit.html.erb
@@ -6,6 +6,5 @@
   </div>
 </div>
 
-<%= render "/admin/budgets/drafting" %>
-
-<%= render "/admin/budgets/form" %>
+<%= render "drafting" %>
+<%= render "form" %>

--- a/app/views/admin/budgets/show.html.erb
+++ b/app/views/admin/budgets/show.html.erb
@@ -1,5 +1,0 @@
-<%= back_link_to admin_budgets_path %>
-
-<h2><%= @budget.name %></h2>
-
-<%= render "form" %>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -84,8 +84,13 @@ en:
         notice: New participatory budget created successfully!
       update:
         notice: Participatory budget updated successfully
+      publish:
+        notice: "Participaroty budget published successfully"
       edit:
         title: Edit Participatory budget
+        drafting: "This participatory budget is in draft mode, only administrators can see it in the public site. Once it's published it cannot be changed to draft mode again."
+        preview: "Preview"
+        publish: "Publish"
         delete: Delete budget
         phase: Phase
         dates: Dates

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -85,7 +85,7 @@ en:
       update:
         notice: Participatory budget updated successfully
       publish:
-        notice: "Participaroty budget published successfully"
+        notice: "Participatory budget published successfully"
       edit:
         title: Edit Participatory budget
         drafting: "This participatory budget is in draft mode, only administrators can see it in the public site. Once it's published it cannot be changed to draft mode again."

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -84,8 +84,13 @@ es:
         notice: '¡Presupuestos participativos creados con éxito!'
       update:
         notice: Presupuestos participativos actualizados
+      publish:
+        notice: "Presupuestos participativos actualizados"
       edit:
         title: Editar presupuestos participativos
+        drafting: "Este presupuesto participativo está en modo borrador, sólo los administradores pueden verlo desde la parte pública de la página. Una vez se haya publicado, no se podrá volver a poner en modo borrador otra vez."
+        preview: "Previsualizar"
+        publish: "Publicar"
         delete: Eliminar presupuesto
         phase: Fase
         dates: Fechas

--- a/config/locales/es/admin.yml
+++ b/config/locales/es/admin.yml
@@ -88,7 +88,7 @@ es:
         notice: "Presupuestos participativos actualizados"
       edit:
         title: Editar presupuestos participativos
-        drafting: "Este presupuesto participativo está en modo borrador, sólo los administradores pueden verlo desde la parte pública de la página. Una vez se haya publicado, no se podrá volver a poner en modo borrador otra vez."
+        drafting: "Este presupuesto participativo está en modo borrador, solo los administradores pueden verlo desde la parte pública de la página. Una vez se haya publicado, no se podrá volver a poner en modo borrador otra vez."
         preview: "Previsualizar"
         publish: "Publicar"
         delete: Eliminar presupuesto

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -53,6 +53,7 @@ namespace :admin do
 
   resources :budgets do
     member do
+      patch :publish
       put :calculate_winners
     end
 

--- a/db/migrate/20200211123827_add_published_status_to_budgets.rb
+++ b/db/migrate/20200211123827_add_published_status_to_budgets.rb
@@ -1,0 +1,5 @@
+class AddPublishedStatusToBudgets < ActiveRecord::Migration[5.0]
+  def change
+    add_column :budgets, :published, :boolean, default: true
+  end
+end

--- a/db/migrate/20200211123827_add_published_status_to_budgets.rb
+++ b/db/migrate/20200211123827_add_published_status_to_budgets.rb
@@ -1,5 +1,5 @@
-class AddPublishedStatusToBudgets < ActiveRecord::Migration[5.0]
+class AddPublishedStatusToBudgets < ActiveRecord::Migration[5.1]
   def change
-    add_column :budgets, :published, :boolean, default: true
+    add_column :budgets, :published, :boolean
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -360,7 +360,7 @@ ActiveRecord::Schema.define(version: 20200519120717) do
     t.text "description_drafting"
     t.text "description_publishing_prices"
     t.text "description_informing"
-    t.boolean "published", default: true
+    t.boolean "published"
   end
 
   create_table "campaigns", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -360,6 +360,7 @@ ActiveRecord::Schema.define(version: 20200519120717) do
     t.text "description_drafting"
     t.text "description_publishing_prices"
     t.text "description_informing"
+    t.boolean "published", default: true
   end
 
   create_table "campaigns", id: :serial, force: :cascade do |t|

--- a/lib/tasks/budgets.rake
+++ b/lib/tasks/budgets.rake
@@ -10,4 +10,18 @@ namespace :budgets do
       Budget.last.email_unselected
     end
   end
+
+  desc "Update existing budgets in drafting phase"
+  task update_drafting_budgets: :environment do
+    Budget.where(phase: "drafting").each do |budget|
+      if budget.phases.enabled.first.present?
+        next_enabled_phase = budget.phases.enabled.first.kind
+      else
+        next_enabled_phase = "informing"
+        budget.phases.informing.update!(enabled: true)
+      end
+      budget.update!(phase: next_enabled_phase)
+      budget.update!(published: false)
+    end
+  end
 end

--- a/lib/tasks/budgets.rake
+++ b/lib/tasks/budgets.rake
@@ -11,17 +11,22 @@ namespace :budgets do
     end
   end
 
-  desc "Update existing budgets in drafting phase"
-  task update_drafting_budgets: :environment do
-    Budget.where(phase: "drafting").each do |budget|
-      if budget.phases.enabled.first.present?
-        next_enabled_phase = budget.phases.enabled.first.kind
+  desc "Set published attribute"
+  task set_published: :environment do
+    Budget.where(published: nil).each do |budget|
+      if budget.phase == "drafting"
+        if budget.phases.enabled.first.present?
+          next_enabled_phase = budget.phases.enabled.first.kind
+        else
+          next_enabled_phase = "informing"
+          budget.phases.informing.update!(enabled: true)
+        end
+
+        budget.update!(phase: next_enabled_phase)
+        budget.update!(published: false)
       else
-        next_enabled_phase = "informing"
-        budget.phases.informing.update!(enabled: true)
+        budget.update!(published: true)
       end
-      budget.update!(phase: next_enabled_phase)
-      budget.update!(published: false)
     end
   end
 end

--- a/lib/tasks/consul.rake
+++ b/lib/tasks/consul.rake
@@ -1,5 +1,11 @@
 namespace :consul do
   desc "Runs tasks needed to upgrade to the latest version"
   task execute_release_tasks: ["settings:rename_setting_keys",
-                               "settings:add_new_settings"]
+                               "settings:add_new_settings",
+                               "execute_release_1.2.0_tasks"]
+
+  desc "Runs tasks needed to upgrade from 1.1.0 to 1.2.0"
+  task "execute_release_1.2.0_tasks": [
+    "budgets:update_drafting_budgets"
+  ]
 end

--- a/lib/tasks/consul.rake
+++ b/lib/tasks/consul.rake
@@ -6,6 +6,6 @@ namespace :consul do
 
   desc "Runs tasks needed to upgrade from 1.1.0 to 1.2.0"
   task "execute_release_1.2.0_tasks": [
-    "budgets:update_drafting_budgets"
+    "budgets:set_published"
   ]
 end

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     description_finished { "This budget is finished" }
 
     trait :drafting do
-      phase { "drafting" }
+      published { false }
     end
 
     trait :informing do

--- a/spec/factories/budgets.rb
+++ b/spec/factories/budgets.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :budget do
     sequence(:name) { |n| "#{Faker::Lorem.word} #{n}" }
     currency_symbol { "€" }
+    published { true }
     phase { "accepting" }
     description_drafting  { "This budget is drafting" }
     description_informing { "This budget is informing" }

--- a/spec/lib/tasks/budgets_spec.rb
+++ b/spec/lib/tasks/budgets_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe Budget do
+  let(:run_rake_task) do
+    Rake::Task["budgets:update_drafting_budgets"].reenable
+    Rake.application.invoke_task("budgets:update_drafting_budgets")
+  end
+
+  it "does not change anything if there are not budgets in draft mode" do
+    budget = create(:budget)
+
+    expect(budget.phase).to eq "accepting"
+    expect(budget.published).to be true
+
+    run_rake_task
+    budget.reload
+
+    expect(budget.phase).to eq "accepting"
+    expect(budget.published).to be true
+  end
+
+  it "changes the published attribut to false" do
+    budget = create(:budget)
+    budget.update_columns(phase: "drafting")
+
+    expect(budget.published).to be true
+
+    run_rake_task
+    budget.reload
+
+    expect(budget.published).to be false
+  end
+
+  it "changes the phase to the first enabled phase" do
+    budget = create(:budget)
+    budget.update_columns(phase: "drafting")
+    budget.phases.informing.update!(enabled: false)
+
+    expect(budget.phase).to eq "drafting"
+
+    run_rake_task
+    budget.reload
+
+    expect(budget.phase).to eq "accepting"
+  end
+
+  it "enables and select the informing phase if there are not any enabled phases" do
+    budget = create(:budget)
+    budget.update_columns(phase: "drafting")
+    budget.phases.each { |phase| phase.update!(enabled: false) }
+
+    expect(budget.phase).to eq "drafting"
+
+    run_rake_task
+    budget.reload
+
+    expect(budget.phase).to eq "informing"
+    expect(budget.phases.informing.enabled).to be true
+  end
+end

--- a/spec/models/budget/phase_spec.rb
+++ b/spec/models/budget/phase_spec.rb
@@ -1,12 +1,11 @@
 require "rails_helper"
 
 describe Budget::Phase do
-  let(:budget)       { create(:budget) }
-  let(:first_phase)  { budget.phases.drafting }
-  let(:second_phase)  { budget.phases.informing }
-  let(:third_phase) { budget.phases.accepting }
-  let(:fourth_phase)  { budget.phases.reviewing }
-  let(:final_phase) { budget.phases.finished }
+  let(:budget)          { create(:budget) }
+  let(:informing_phase) { budget.phases.informing }
+  let(:accepting_phase) { budget.phases.accepting }
+  let(:reviewing_phase) { budget.phases.reviewing }
+  let(:finished_phase)  { budget.phases.finished }
 
   it_behaves_like "globalizable", :budget_phase
 
@@ -31,54 +30,53 @@ describe Budget::Phase do
 
     describe "#dates_range_valid?" do
       it "is valid when start & end dates are different & consecutive" do
-        first_phase.assign_attributes(starts_at: Date.current, ends_at: Date.tomorrow)
+        informing_phase.assign_attributes(starts_at: Date.current, ends_at: Date.tomorrow)
 
-        expect(first_phase).to be_valid
+        expect(informing_phase).to be_valid
       end
 
       it "is not valid when dates are equal" do
-        first_phase.assign_attributes(starts_at: Date.current, ends_at: Date.current)
+        informing_phase.assign_attributes(starts_at: Date.current, ends_at: Date.current)
 
-        expect(first_phase).not_to be_valid
+        expect(informing_phase).not_to be_valid
       end
 
       it "is not valid when start date is later than end date" do
-        first_phase.assign_attributes(starts_at: Date.tomorrow, ends_at: Date.current)
+        informing_phase.assign_attributes(starts_at: Date.tomorrow, ends_at: Date.current)
 
-        expect(first_phase).not_to be_valid
+        expect(informing_phase).not_to be_valid
       end
     end
 
     describe "#prev_phase_dates_valid?" do
       let(:error) do
-        "Start date must be later than the start date of the previous enabled phase"\
-        " (Draft (Not visible to the public))"
+        "Start date must be later than the start date of the previous enabled phase (Information)"
       end
 
       it "is invalid when start date is same as previous enabled phase start date" do
-        second_phase.assign_attributes(starts_at: second_phase.prev_enabled_phase.starts_at)
+        accepting_phase.assign_attributes(starts_at: accepting_phase.prev_enabled_phase.starts_at)
 
-        expect(second_phase).not_to be_valid
-        expect(second_phase.errors.messages[:starts_at]).to include(error)
+        expect(accepting_phase).not_to be_valid
+        expect(accepting_phase.errors.messages[:starts_at]).to include(error)
       end
 
       it "is invalid when start date is earlier than previous enabled phase start date" do
-        second_phase.assign_attributes(starts_at: second_phase.prev_enabled_phase.starts_at - 1.day)
+        accepting_phase.assign_attributes(starts_at: accepting_phase.prev_enabled_phase.starts_at - 1.day)
 
-        expect(second_phase).not_to be_valid
-        expect(second_phase.errors.messages[:starts_at]).to include(error)
+        expect(accepting_phase).not_to be_valid
+        expect(accepting_phase.errors.messages[:starts_at]).to include(error)
       end
 
       it "is valid when start date is in between previous enabled phase start & end dates" do
-        second_phase.assign_attributes(starts_at: second_phase.prev_enabled_phase.starts_at + 1.day)
+        accepting_phase.assign_attributes(starts_at: accepting_phase.prev_enabled_phase.starts_at + 1.day)
 
-        expect(second_phase).to be_valid
+        expect(accepting_phase).to be_valid
       end
 
       it "is valid when start date is later than previous enabled phase end date" do
-        second_phase.assign_attributes(starts_at: second_phase.prev_enabled_phase.ends_at + 1.day)
+        accepting_phase.assign_attributes(starts_at: accepting_phase.prev_enabled_phase.ends_at + 1.day)
 
-        expect(second_phase).to be_valid
+        expect(accepting_phase).to be_valid
       end
     end
 
@@ -88,29 +86,29 @@ describe Budget::Phase do
       end
 
       it "is invalid when end date is same as next enabled phase end date" do
-        second_phase.assign_attributes(ends_at: second_phase.next_enabled_phase.ends_at)
+        informing_phase.assign_attributes(ends_at: informing_phase.next_enabled_phase.ends_at)
 
-        expect(second_phase).not_to be_valid
-        expect(second_phase.errors.messages[:ends_at]).to include(error)
+        expect(informing_phase).not_to be_valid
+        expect(informing_phase.errors.messages[:ends_at]).to include(error)
       end
 
       it "is invalid when end date is later than next enabled phase end date" do
-        second_phase.assign_attributes(ends_at: second_phase.next_enabled_phase.ends_at + 1.day)
+        informing_phase.assign_attributes(ends_at: informing_phase.next_enabled_phase.ends_at + 1.day)
 
-        expect(second_phase).not_to be_valid
-        expect(second_phase.errors.messages[:ends_at]).to include(error)
+        expect(informing_phase).not_to be_valid
+        expect(informing_phase.errors.messages[:ends_at]).to include(error)
       end
 
       it "is valid when end date is in between next enabled phase start & end dates" do
-        second_phase.assign_attributes(ends_at: second_phase.next_enabled_phase.ends_at - 1.day)
+        informing_phase.assign_attributes(ends_at: informing_phase.next_enabled_phase.ends_at - 1.day)
 
-        expect(second_phase).to be_valid
+        expect(informing_phase).to be_valid
       end
 
       it "is valid when end date is earlier than next enabled phase start date" do
-        second_phase.assign_attributes(ends_at: second_phase.next_enabled_phase.starts_at - 1.day)
+        informing_phase.assign_attributes(ends_at: informing_phase.next_enabled_phase.starts_at - 1.day)
 
-        expect(second_phase).to be_valid
+        expect(informing_phase).to be_valid
       end
     end
   end
@@ -128,50 +126,50 @@ describe Budget::Phase do
   end
 
   describe "#adjust_date_ranges" do
-    let(:prev_enabled_phase) { second_phase.prev_enabled_phase }
-    let(:next_enabled_phase) { second_phase.next_enabled_phase }
+    let(:prev_enabled_phase) { accepting_phase.prev_enabled_phase }
+    let(:next_enabled_phase) { accepting_phase.next_enabled_phase }
 
     describe "when enabled" do
       it "adjusts previous enabled phase end date to its own start date" do
-        expect(prev_enabled_phase.ends_at).to eq(second_phase.starts_at)
+        expect(prev_enabled_phase.ends_at).to eq(accepting_phase.starts_at)
       end
 
       it "adjusts next enabled phase start date to its own end date" do
-        expect(next_enabled_phase.starts_at).to eq(second_phase.ends_at)
+        expect(next_enabled_phase.starts_at).to eq(accepting_phase.ends_at)
       end
     end
 
     describe "when being enabled" do
       before do
-        second_phase.update!(enabled: false,
+        accepting_phase.update!(enabled: false,
                              starts_at: Date.current,
                              ends_at:  Date.current + 2.days)
       end
 
       it "adjusts previous enabled phase end date to its own start date" do
-        expect { second_phase.update(enabled: true) }
+        expect { accepting_phase.update(enabled: true) }
           .to change { prev_enabled_phase.ends_at.to_date }.to(Date.current)
       end
 
       it "adjusts next enabled phase start date to its own end date" do
         expect do
-          second_phase.update(enabled: true)
+          accepting_phase.update(enabled: true)
         end.to change { next_enabled_phase.starts_at.to_date }.to(Date.current + 2.days)
       end
     end
 
     describe "when disabled" do
       before do
-        second_phase.update!(enabled: false)
+        accepting_phase.update!(enabled: false)
       end
 
       it "doesn't change previous enabled phase end date" do
-        expect { second_phase.update(starts_at: Date.current, ends_at:  Date.current + 2.days) }
+        expect { accepting_phase.update(starts_at: Date.current, ends_at:  Date.current + 2.days) }
           .not_to change { prev_enabled_phase.ends_at }
       end
 
       it "doesn't change next enabled phase start date" do
-        expect { second_phase.update(starts_at: Date.current, ends_at:  Date.current + 2.days) }
+        expect { accepting_phase.update(starts_at: Date.current, ends_at:  Date.current + 2.days) }
           .not_to change { next_enabled_phase.starts_at }
       end
     end
@@ -179,7 +177,7 @@ describe Budget::Phase do
     describe "when being disabled" do
       it "doesn't adjust previous enabled phase end date to its own start date" do
         expect do
-          second_phase.update(enabled: false,
+          accepting_phase.update(enabled: false,
                               starts_at: Date.current,
                               ends_at:  Date.current + 2.days)
         end.not_to change { prev_enabled_phase.ends_at }
@@ -187,7 +185,7 @@ describe Budget::Phase do
 
       it "adjusts next enabled phase start date to its own start date" do
         expect do
-          second_phase.update(enabled: false,
+          accepting_phase.update(enabled: false,
                               starts_at: Date.current,
                               ends_at:  Date.current + 2.days)
         end.to change { next_enabled_phase.starts_at.to_date }.to(Date.current)
@@ -197,22 +195,25 @@ describe Budget::Phase do
 
   describe "next & prev enabled phases" do
     before do
-      second_phase.update(enabled: false)
+      accepting_phase.update!(enabled: false)
+      %w[selecting reviewing_ballots balloting publishing_prices valuating].each do |phase|
+        budget.phases.send(phase).update(enabled: false)
+      end
     end
 
     describe "#next_enabled_phase" do
       it "returns the right next enabled phase" do
-        expect(first_phase.reload.next_enabled_phase).to eq(third_phase)
-        expect(third_phase.reload.next_enabled_phase).to eq(fourth_phase)
-        expect(final_phase.reload.next_enabled_phase).to eq(nil)
+        expect(informing_phase.reload.next_enabled_phase).to eq(reviewing_phase)
+        expect(reviewing_phase.reload.next_enabled_phase).to eq(finished_phase)
+        expect(finished_phase.reload.next_enabled_phase).to eq(nil)
       end
     end
 
     describe "#prev_enabled_phase" do
       it "returns the right previous enabled phase" do
-        expect(first_phase.reload.prev_enabled_phase).to eq(nil)
-        expect(third_phase.reload.prev_enabled_phase).to eq(first_phase)
-        expect(fourth_phase.reload.prev_enabled_phase).to eq(third_phase)
+        expect(informing_phase.reload.prev_enabled_phase).to eq(nil)
+        expect(reviewing_phase.reload.prev_enabled_phase).to eq(informing_phase)
+        expect(finished_phase.reload.prev_enabled_phase).to eq(reviewing_phase)
       end
     end
   end

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -96,9 +96,6 @@ describe Budget do
     end
 
     it "produces auxiliary methods" do
-      budget.phase = "drafting"
-      expect(budget).to be_drafting
-
       budget.phase = "accepting"
       expect(budget).to be_accepting
 
@@ -246,7 +243,6 @@ describe Budget do
   end
 
   describe "#generate_phases" do
-    let(:drafting_phase)          { budget.phases.drafting }
     let(:informing_phase)         { budget.phases.informing }
     let(:accepting_phase)         { budget.phases.accepting }
     let(:reviewing_phase)         { budget.phases.reviewing }
@@ -260,7 +256,6 @@ describe Budget do
     it "generates all phases linked in correct order" do
       expect(budget.phases.count).to eq(Budget::Phase::PHASE_KINDS.count)
 
-      expect(drafting_phase.next_phase).to eq(informing_phase)
       expect(informing_phase.next_phase).to eq(accepting_phase)
       expect(accepting_phase.next_phase).to eq(reviewing_phase)
       expect(reviewing_phase.next_phase).to eq(selecting_phase)
@@ -271,8 +266,7 @@ describe Budget do
       expect(reviewing_ballots_phase.next_phase).to eq(finished_phase)
       expect(finished_phase.next_phase).to eq(nil)
 
-      expect(drafting_phase.prev_phase).to eq(nil)
-      expect(informing_phase.prev_phase).to eq(drafting_phase)
+      expect(informing_phase.prev_phase).to eq(nil)
       expect(accepting_phase.prev_phase).to eq(informing_phase)
       expect(reviewing_phase.prev_phase).to eq(accepting_phase)
       expect(selecting_phase.prev_phase).to eq(reviewing_phase)

--- a/spec/models/budget_spec.rb
+++ b/spec/models/budget_spec.rb
@@ -32,6 +32,36 @@ describe Budget do
         expect(Budget.valuating_or_later).to be_empty
       end
     end
+
+    describe ".drafting" do
+      it "returns unpublished budgets" do
+        undefined = create(:budget, published: nil)
+        drafting = create(:budget, published: false)
+
+        expect(Budget.drafting).to match_array([undefined, drafting])
+      end
+
+      it "does not return published budgets" do
+        create(:budget, published: true)
+
+        expect(Budget.drafting).to be_empty
+      end
+    end
+
+    describe ".published" do
+      it "does not return unpublished budgets" do
+        create(:budget, published: nil)
+        create(:budget, published: false)
+
+        expect(Budget.published).to be_empty
+      end
+
+      it "returns published budgets" do
+        published = create(:budget, published: true)
+
+        expect(Budget.published).to eq [published]
+      end
+    end
   end
 
   describe "name" do

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -20,18 +20,20 @@ describe "Admin budgets" do
     let!(:budget) { create(:budget, slug: "budget_slug") }
 
     scenario "finds budget by slug" do
-      visit admin_budget_path("budget_slug")
+      visit edit_admin_budget_path("budget_slug")
+
+      expect(page).to have_content("Edit Participatory budget")
     end
 
     scenario "raises an error if budget slug is not found" do
       expect do
-        visit admin_budget_path("wrong_budget")
+        visit edit_admin_budget_path("wrong_budget")
       end.to raise_error ActiveRecord::RecordNotFound
     end
 
     scenario "raises an error if budget id is not found" do
       expect do
-        visit admin_budget_path(0)
+        visit edit_admin_budget_path(0)
       end.to raise_error ActiveRecord::RecordNotFound
     end
   end
@@ -143,13 +145,13 @@ describe "Admin budgets" do
     let(:budget) { create(:budget, :drafting) }
 
     scenario "Can preview budget before and after it is published" do
-      visit admin_budget_path(budget)
+      visit edit_admin_budget_path(budget)
 
       click_link "Preview"
 
       expect(page).to have_current_path budget_path(budget)
 
-      visit admin_budget_path(budget)
+      visit edit_admin_budget_path(budget)
       budget.update!(published: true)
 
       click_link "Preview"
@@ -158,7 +160,7 @@ describe "Admin budgets" do
     end
 
     scenario "Publishing a budget" do
-      visit admin_budget_path(budget)
+      visit edit_admin_budget_path(budget)
 
       click_link "Publish"
 

--- a/spec/system/admin/budgets_spec.rb
+++ b/spec/system/admin/budgets_spec.rb
@@ -152,8 +152,7 @@ describe "Admin budgets" do
       visit admin_budget_path(budget)
       budget.update!(published: true)
 
-      expect(page).to have_link "Preview budget"
-      click_link "Preview budget"
+      click_link "Preview"
 
       expect(page).to have_current_path budget_path(budget)
     end
@@ -163,8 +162,8 @@ describe "Admin budgets" do
 
       click_link "Publish"
 
-      expect(page).to have_content "Participaroty budget published successfully"
-      expect(page).to have_link "Preview budget"
+      expect(page).to have_content "Participatory budget published successfully"
+      expect(page).to have_link "Preview"
       expect(page).not_to have_content "This participatory budget is in draft mode"
       expect(page).not_to have_link "Publish budget"
     end

--- a/spec/system/budgets/budgets_spec.rb
+++ b/spec/system/budgets/budgets_spec.rb
@@ -168,7 +168,7 @@ describe "Budgets" do
     scenario "Not show investment links earlier of balloting " do
       budget = create(:budget)
       create(:budget_heading, budget: budget)
-      phases_without_links = ["drafting", "informing"]
+      phases_without_links = ["informing"]
       not_allowed_phase_list = Budget::Phase::PHASE_KINDS -
                                phases_without_links -
                                allowed_phase_list
@@ -205,9 +205,10 @@ describe "Budgets" do
   scenario "Index shows only published phases" do
     budget.update!(phase: :finished)
     phases = budget.phases
-    phases.drafting.update!(starts_at: "30-12-2017", ends_at: "31-12-2017", enabled: true,
-                           description: "Description of drafting phase",
-                           summary: "<p>This is the summary for drafting phase</p>")
+
+    phases.informing.update!(starts_at: "30-12-2017", ends_at: "31-12-2017", enabled: true,
+                             description: "Description of informing phase",
+                             summary: "<p>This is the summary for informing phase</p>")
 
     phases.accepting.update!(starts_at: "01-01-2018", ends_at: "10-01-2018", enabled: true,
                             description: "Description of accepting phase",
@@ -243,8 +244,6 @@ describe "Budgets" do
 
     visit budgets_path
 
-    expect(page).not_to have_content "This is the summary for drafting phase"
-    expect(page).not_to have_content "December 30, 2017 - December 31, 2017"
     expect(page).not_to have_content "This is the summary for reviewing phase"
     expect(page).not_to have_content "January 11, 2018 - January 20, 2018"
     expect(page).not_to have_content "This is the summary for valuating phase"
@@ -254,6 +253,8 @@ describe "Budgets" do
     expect(page).not_to have_content "This is the summary for reviewing_ballots phase"
     expect(page).not_to have_content "March 11, 2018 - March 20, 2018"
 
+    expect(page).to have_content "This is the summary for informing phase"
+    expect(page).to have_content "December 30, 2017 - December 31, 2017"
     expect(page).to have_content "This is the summary for accepting phase"
     expect(page).to have_content "January 01, 2018 - January 20, 2018"
     expect(page).to have_content "This is the summary for selecting phase"
@@ -478,7 +479,7 @@ describe "Budgets" do
 
     before do
       logout
-      budget.update!(phase: "drafting")
+      budget.update!(published: false)
       create(:budget)
     end
 


### PR DESCRIPTION
Previously the draft mode was a phase of the PB, but that had some
limitations.

Now the phase drafting disappears and therefore the PB can have the
status published or not published (in draft mode).

That will give more flexibility in order to navigate through the
different phases and see how it looks for administrators before
publishing the PB and everybody can see.

By default, the PB is always created in draft mode, so it gives you
the flexibility to adjust and modify anything before publishing it.